### PR TITLE
Support for non-GNU find

### DIFF
--- a/test/install.sh
+++ b/test/install.sh
@@ -5,7 +5,7 @@ dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd)"
 cd $dir/../daemon
 lein uberjar
 mkdir -p ~/.inlein/daemons
-find -iname '*-standalone.jar' -exec cp -t ~/.inlein/daemons {} \;
+find . -iname '*-standalone.jar' -exec cp -t ~/.inlein/daemons {} \;
 
 cd $dir/../client
 lein uberjar


### PR DESCRIPTION
Adding '.' so that test/install.sh will also work with non-GNU find.