### PR TITLE
Add repl task

### DIFF
--- a/client/src/inlein/client/Main.java
+++ b/client/src/inlein/client/Main.java
@@ -42,6 +42,7 @@ public class Main {
         tasks.put(Version.instance.taskname, Version.instance);
         tasks.put(Ping.instance.taskname, Ping.instance);
         tasks.put(Run.instance.taskname, Run.instance);
+        tasks.put(Repl.instance.taskname, Repl.instance);
         tasks.put(ShutdownDaemon.instance.taskname, ShutdownDaemon.instance);
         tasks.put(StartDaemon.instance.taskname, StartDaemon.instance);
         tasks.put(RestartDaemon.instance.taskname, RestartDaemon.instance);

--- a/client/src/inlein/client/tasks/Repl.java
+++ b/client/src/inlein/client/tasks/Repl.java
@@ -12,13 +12,17 @@ public final class Repl extends Task {
     private Repl() {
         super("--repl",
               "Runs a clojure repl, optionally running a script and/or loading extra dependencies",
-              "Runs a clojure repl, optionally running a script and/or loading extra dependencies");
+              "Runs a clojure repl, optionally running a script and/or loading extra dependencies.\n" +
+              "Takes arguments: [--deps dep1[,dep2...]] [file [args...]]\n" +
+              "where deps is a comma-separated list of an extended version of maven coordinates:\n" +
+              "group:artifact[:type[:classifier]]:version, where if type and classifier are omitted\n" +
+              "then group and version are also optional, defaulting to the same as artifact and LATEST respectively\n" +
+              "and version ranges use semicolons instead of commas (to avoid conflicting with the separator)\n" +
+              "e.g. org.clojure:clojure, clj-time:0.14.0, org.jclouds:jclouds:jar:jdk17:[2.0.0;2.1)");
     }
 
     private void die() {
-        System.out.println("repl expects [--deps dep1[;dep2...]] [file [args...]]\n" +
-                           "where deps are semicolon-separated maven coordinates (with group optional if type+classifier also omitted)\n" +
-                           "i.e. [group:]artifact[:type[:classifier]]:version (e.g. clj-time:0.14.0 / org.jclouds:jclouds:1.0:jar:jdk15)");
+        System.out.println("repl expects [--deps dep1[,dep2...]] [file [args...]]\n");
         System.exit(1);
     }
 
@@ -29,7 +33,7 @@ public final class Repl extends Task {
             if (args.length < 2) {
                 die();
             }
-            coords += ";" + args[1];
+            coords = args[1] + "," + coords;
             script = 2;
         }
         conn = ServerConnection.ensureConnected(conn);

--- a/client/src/inlein/client/tasks/Repl.java
+++ b/client/src/inlein/client/tasks/Repl.java
@@ -1,0 +1,80 @@
+package inlein.client.tasks;
+
+import inlein.client.*;
+import inlein.client.signals.Registerer;
+import java.nio.file.*;
+import java.util.*;
+
+public final class Repl extends Task {
+
+    public static final Repl instance = new Repl();
+
+    private Repl() {
+        super("--repl",
+              "Runs a clojure repl, optionally running a script and/or loading extra dependencies",
+              "Runs a clojure repl, optionally running a script and/or loading extra dependencies");
+    }
+
+    private void die() {
+        System.out.println("repl expects [--deps dep1[;dep2...]] [file [args...]]\n" +
+                           "where deps are semicolon-separated maven coordinates (with group optional if type+classifier also omitted)\n" +
+                           "i.e. [group:]artifact[:type[:classifier]]:version (e.g. clj-time:0.14.0 / org.jclouds:jclouds:1.0:jar:jdk15)");
+        System.exit(1);
+    }
+
+    public void run(ServerConnection conn, String[] args) throws Exception {
+        String coords = "reply:0.3.7";
+        int script = 0;
+        if (args.length > 0 && "--deps".equals(args[0])) {
+            if (args.length < 2) {
+                die();
+            }
+            coords += ";" + args[1];
+            script = 2;
+        }
+        conn = ServerConnection.ensureConnected(conn);
+        Map<String, Object> req = new HashMap<>();
+        req.put("op", "jvm-opts");
+        req.put("deps", coords);
+        if (script < args.length) req.put("file", Paths.get(args[script]).toAbsolutePath().toString());
+        Map<String, Object> reply = conn.sendRequest(req);
+
+        String javaCmd = System.getenv("JAVA_CMD");
+        if (javaCmd == null) {
+            javaCmd = "java";
+        }
+        ArrayList<String> cmdArgs = new ArrayList<String>();
+        cmdArgs.add(javaCmd);
+        cmdArgs.addAll((List<String>) reply.get("jvm-opts"));
+        if (script < args.length) {
+            cmdArgs.add(String.format("-D$0=%s", args[script]));
+        }
+        cmdArgs.add("reply.ReplyMain");
+        cmdArgs.add("--standalone");
+        if (script < args.length) {
+            cmdArgs.add("--init");
+            for (int i = script; i < args.length; ++i) {
+                cmdArgs.add(args[i]);
+            }
+        }
+
+        ProcessBuilder pb = new ProcessBuilder(cmdArgs);
+        pb.inheritIO();
+        Process proc = pb.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(new ProcessKiller(proc)));
+        Registerer.dropSignals();
+        proc.waitFor();
+        System.exit(proc.exitValue());
+    }
+
+    private static class ProcessKiller implements Runnable {
+        final Process proc;
+        ProcessKiller(Process proc) {
+            this.proc = proc;
+        }
+
+        public void run() {
+            proc.destroy();
+        }
+    }
+}

--- a/daemon/src/inlein/daemon/read_script.clj
+++ b/daemon/src/inlein/daemon/read_script.clj
@@ -46,9 +46,9 @@
         (throw (ex-info msg {:error msg}))))))
 
 (defn- extract-jvm-opts
-  [params opts]
+  [params extra-deps opts]
   (let [params (deps/add-global-exclusions params)
-        cp-string (deps/classpath-string (:dependencies params)
+        cp-string (deps/classpath-string (concat (:dependencies params) extra-deps)
                                          (select-keys opts [:transfer-listener]))]
     {:jvm-opts (concat (:jvm-opts params ["-XX:+TieredCompilation" "-XX:TieredStopAtLevel=1"])
                        ["-cp" cp-string])}))
@@ -125,16 +125,39 @@
       (assoc-nonempty :jvm-opts (cat-merge :jvm-opts params))
       (assoc-nonempty :exclusions (cat-merge :exclusions (reverse params)))))
 
+(defn- convert-maven-dep
+  ([artifact version]
+   (convert-maven-dep nil artifact nil nil version))
+  ([group artifact version]
+   (convert-maven-dep group artifact nil nil version))
+  ([group artifact packaging version]
+   (convert-maven-dep group artifact packaging nil version))
+  ([group artifact packaging classifier version]
+   (cond-> [(symbol (if group
+                      (str group "/" artifact)
+                      artifact))
+            version]
+     packaging  (conj :extension packaging)
+     classifier (conj :classifier classifier))))
+
+(defn- parse-maven-deps
+  [deps-str]
+  (->> (c.str/split (or deps-str "") #";")
+       (remove empty?)
+       (mapv #(apply convert-maven-dep (c.str/split % #":")))))
+
 (defn read-script-params
   ([fname]
-   (read-script-params fname {}))
-  ([fname opts]
-   (let [fname (utils/abs-path fname)]
-     (binding [*root* fname]
-       (let [all-params (all-file-params fname)
-             _ (detect-cycles all-params (ordered.set/ordered-set fname))
-             order (toposort all-params fname (ordered.set/ordered-set))
-             params (merge-params (map all-params order))]
-         (-> params
-             (extract-jvm-opts (select-keys opts [:transfer-listener]))
-             (assoc :files (seq order))))))))
+   (read-script-params fname nil {}))
+  ([fname deps opts]
+   (if fname
+     (let [fname (utils/abs-path fname)]
+       (binding [*root* fname]
+         (let [all-params (all-file-params fname)
+               _ (detect-cycles all-params (ordered.set/ordered-set fname))
+               order (toposort all-params fname (ordered.set/ordered-set))
+               params (merge-params (map all-params order))]
+           (-> params
+               (extract-jvm-opts (parse-maven-deps deps) (select-keys opts [:transfer-listener]))
+               (assoc :files (seq order))))))
+     (extract-jvm-opts {} (parse-maven-deps deps) (select-keys opts [:transfer-listener])))))

--- a/daemon/src/inlein/daemon/server.clj
+++ b/daemon/src/inlein/daemon/server.clj
@@ -69,7 +69,7 @@
   (let [log-fn (deps/transfer-logger (fn [s]
                                        (info out s)
                                        (println s)))]
-    (write-response out op (rs/read-script-params (:file op)
+    (write-response out op (rs/read-script-params (:file op) (:deps op)
                                                   {:transfer-listener log-fn}))))
 
 (defmethod handle-request :default [op in out]


### PR DESCRIPTION
I updated the code linked from #8 and rebased on to the latest master. With this you can run:
- `inlein --repl file.clj`: run the script in `file.clj`, similarly to the `--run` task, but leave you at a REPL.
- `inlein --repl --deps artifact1:0.1.0;group:artifact2:2.0.0`: load one or more dependencies (specified as a semicolon-separated list of [maven coordinates](https://maven.apache.org/pom.html#Maven_Coordinates)) into a REPL.
- combine both to load more dependencies in addition to those specified in the script file (e.g. a debugging or profiling library).

Normally the group, artifact and version are obligatory in a maven coordinate, but I allow the group to be omitted (if type/packaging and classifier are also omitted), in which case it defaults to the same as the artifact name (as in leiningen dependency vectors). I decided on semicolons as a separator as opposed to commas because commas can be used to specify version ranges (e.g. `org.clojure:clojure:[1.8.0,2.0)`), while I don't think semicolons are valid in maven coordinates (AFAIK, at least I've never seen it).

I found that this makes `inlein` really handy for quickly firing up a REPL to experiment with one or more dependencies, or debugging an inlein script.

Some possible improvements could be:
- the leiningen dependency vector format is probably more familiar for most people (e.g. `[org.clojure/clojure "1.8.0"]`, so maybe that should be used for the dependencies (although it is a bit more awkward to write on the command line because of the spaces and quotes). Maybe both could be accepted, and the two could be distinguished by the presence or not of square brackets (e.g.: `--deps 'org.clojure:clojure:1.8.0;[clj-time "0.14.0"]'`)
- better way of specifying Clojure version: currently it will load Clojure 1.4.0 unless a different version is specified as a dependency (either to `--deps` or in the script file). And if you specify a version in `--deps` it will override any other version in the script file. It would be nice if the default were the latest (stable) version unless an explicit version is specified.
- it could be useful to load a REPL with the dependencies from a script file, without executing the code in the file. Maybe adding a .clj file to the `--deps` list could do that?
- could it also understand a `project.clj` in the dependencies and load the dependencies from there (and the code of that project)?
- what about specifying the path to a jar file in the dependencies?