### PR TITLE
Make install script run on Mac OS X

### DIFF
--- a/client/executable-jars.sh
+++ b/client/executable-jars.sh
@@ -7,7 +7,7 @@ if [ $# -ne 1 ]; then
 fi
 
 vsn="$1"
-base=$(dirname $(readlink -f "$0"))
+base=$(dirname "$0")
 jarfile="$base/target/inlein-$vsn.jar"
 
 if [ ! -f "$jarfile" ]; then

--- a/test/install.sh
+++ b/test/install.sh
@@ -5,7 +5,7 @@ dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd)"
 cd $dir/../daemon
 lein uberjar
 mkdir -p ~/.inlein/daemons
-find . -iname '*-standalone.jar' -exec cp -t ~/.inlein/daemons {} \;
+find . -iname '*-standalone.jar' -exec cp {} ~/.inlein/daemons/ \;
 
 cd $dir/../client
 lein uberjar


### PR DESCRIPTION
On Mac OS X:
- `cp` doesn't understand the `-t` option, I think the way I changed it is equivalent
- `readlink` doesn't understand the `-f` option and I had to remove `readlink` completely, not sure how necessary it was / if there is an equivalent on Mac OS X.